### PR TITLE
build(makefile): add a formatting rule

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,25 @@
+# Partly inspired by QT coding style
+BasedOnStyle: WebKit
+Language: Cpp
+ColumnLimit: 100
+PointerBindsToType: false
+BreakBeforeBinaryOperators: NonAssignment
+BreakBeforeBraces: Custom
+BraceWrapping:
+    AfterClass: true
+    AfterControlStatement: false
+    AfterEnum: false
+    AfterFunction: true
+    AfterCaseLabel: true
+    AfterNamespace: false
+    AfterObjCDeclaration: false
+    AfterStruct: true
+    AfterUnion: false
+    BeforeCatch: false
+    BeforeElse: false
+    IndentBraces: false
+AlignAfterOpenBracket: true
+AlwaysBreakTemplateDeclarations: true
+AllowShortEnumsOnASingleLine: false
+AllowShortFunctionsOnASingleLine: Empty
+SortIncludes: false

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,8 +8,12 @@ jobs:
       - name: Checkout the repository
         uses: actions/checkout@v3
 
-      - name: Set TOOLS_PATH and run make
-        run: TOOLS_PATH=/home/ubuntu/dev/tools make
+      - name: Checks the formatting
+        run: make format && git diff --quiet
 
       - name: Run cppcheck
         run: make cppcheck
+
+      - name: Set TOOLS_PATH and run make
+        run: TOOLS_PATH=/home/ubuntu/dev/tools make
+

--- a/Makefile
+++ b/Makefile
@@ -23,6 +23,8 @@ CC = $(MSPGCC_BIN_DIR)/msp430-elf-gcc
 RM=rm
 DEBUG = LD_LIBRARY_PATH=$(DEBUG_DRIVERS_DIR) $(DEBUG_BIN_DIR)/mspdebug
 CPPCHECK = cppcheck
+FORMAT = clang-format-12
+
 
 #Files
 TARGET = $(BIN_DIR)/sumo_robot
@@ -55,7 +57,7 @@ $(OBJ_DIR)/%.o: %.c
 
 #Phonies
 
-.PHONY: all clean flash cppcheck
+.PHONY: all clean flash cppcheck format
 
 all: $(TARGET)
 
@@ -71,3 +73,6 @@ cppcheck:
 		-I (INCLUDE_DIRS) \
 		$(SOURCES) \
 		-i external/printf
+
+format:
+	@$(FORMAT) -i $(SOURCES)

--- a/tools/dockerfile
+++ b/tools/dockerfile
@@ -3,7 +3,7 @@ FROM ubuntu:22.04
 #Install necessary packages
 RUN DEBIAN_FRONTEND=noninteractive \
 	apt-get update \
-	&& apt-get install -y wget bzip2 make unzip p7zip-full cppcheck
+	&& apt-get install -y wget bzip2 make unzip p7zip-full cppcheck clang-format-12 git
 
 #Create a non-root user named "ubuntu"
 #But put in root group since GitHub actions needs permissions


### PR DESCRIPTION
All the code in this project should be formatted with the auto-formatter clang-format. Add a Makefile rule to make it easy to format all files in one go from the commandline. .clang-format config file is added.