### PR TITLE
feat(assert): assert handler and led driver

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -90,7 +90,7 @@ CPPCHECK_FLAGS = \
 #Flags
 MCU = msp430f5529
 WFLAGS = -Wall -Wextra -Werror -Wshadow					#warning flags
-CFLAGS = -mmcu=$(MCU) $(WFLAGS) $(addprefix -I,$(INCLUDE_DIRS)) $(DEFINES) -Og -g		#compiler flags
+CFLAGS = -mmcu=$(MCU) $(WFLAGS) -fshort-enums $(addprefix -I,$(INCLUDE_DIRS)) $(DEFINES) -Og -g		#compiler flags
 LDFLAGS = -mmcu=$(MCU) $(DEFINES) $(addprefix -L,$(LIB_DIRS))			#Linker flags
 
 

--- a/Makefile
+++ b/Makefile
@@ -42,10 +42,12 @@ FORMAT = clang-format-12
 TARGET = $(BUILD_DIR)/$(TARGET_NAME)
 
 SOURCES_WITH_HEADERS = \
-		       src/app/drive.c \
-		       src/app/enemy.c \
-		       src/drivers/io.c \
-		       src/drivers/mcu_init.c \
+					   src/common/assert_handler.c \
+					   src/app/drive.c \
+					   src/drivers/led.c \
+					   src/app/enemy.c \
+					   src/drivers/io.c \
+					   src/drivers/mcu_init.c \
 
 
 #SOURCES_WITH_HEADERS = \

--- a/src/common/assert_handler.c
+++ b/src/common/assert_handler.c
@@ -1,0 +1,37 @@
+#include "common/assert_handler.h"
+#include "common/defines.h"
+#include <msp430.h>
+
+/* The TI compiler provides intrinsic support for calling a specific opcode,
+ * which means you can write __op_code(0x4343) to triger a software breakpoint
+ * (when launchpad FET degubber is attached). MSP430-GCC does not have this
+ * intrinsic, but 0x4343 corresponds to assembly instruction "CLR.B R3". */
+
+#define BREAKPOINT __asm volatile("CLR.B R3");
+
+/*Minimize code dependency in this function to reduce the risk of accidently
+ * calling a function with an assert in it, in which would cause the
+ * assert_handler to be called recursively until statck overflow. */
+
+void assert_handler(void) {
+  // Turn off motors ("safe state")
+
+  // Trace to console
+
+  // Breakpoint
+
+  BREAKPOINT
+
+  // Blink LED indefinetly when assertion is triggered.
+
+  // Configure TEST_LED pin on launchpad
+  P1SEL &= ~(BIT0);
+  P1DIR |= (BIT0);
+  P1REN &= ~(BIT0);
+
+  while (1) {
+    // Blink LED on target in case the wrong target was flashed
+    P1OUT ^= BIT0;
+    BUSY_WAIT_ms(250); // 250ms delay
+  }
+}

--- a/src/common/assert_handler.h
+++ b/src/common/assert_handler.h
@@ -1,0 +1,12 @@
+#ifndef ASSERT_HANDLER_H
+
+#define ASSERT(expression)                                                     \
+  do {                                                                         \
+    if (!(expression)) {                                                       \
+      assert_handler();                                                        \
+    }                                                                          \
+  } while (0);
+
+void assert_handler(void);
+
+#endif

--- a/src/common/defines.h
+++ b/src/common/defines.h
@@ -3,4 +3,10 @@
 
 #define UNUSED(x) (void)(x)
 #define ARRAY_SIZE(array) (sizeof(array) / sizeof(array[0]))
+
+// Clock rate calculation when it is set to default 1MHZ
+#define CYCLES_1MHZ (1000000u)
+#define ms_TO_CYCLES(ms) ((CYCLES_1MHZ / 1000u) * ms)
+#define BUSY_WAIT_ms(ms) (__delay_cycles(ms_TO_CYCLES(ms)))
+
 #endif // DEFINES_H

--- a/src/drivers/io.c
+++ b/src/drivers/io.c
@@ -98,6 +98,23 @@ void io_configure(io_e io, const struct io_config *config) {
   io_set_pupd(io, config->pupd_resistor);
 }
 
+void io_get_current_config(io_e io, struct io_config *current_config) {
+  const uint8_t port = io_port(io);
+  const uint8_t pin = io_pin_bit(io);
+  const uint8_t sel1 = *port_sel1_regs[port] & pin;
+  current_config->select = (io_select_e)(sel1);
+  current_config->pupd_resistor = (io_pupd_e)(*port_ren_regs[port] & pin);
+  current_config->dir = (io_dir_e)(*port_dir_regs[port] & pin);
+  current_config->out = (io_out_e)(*port_out_regs[port] & pin);
+}
+
+bool io_config_compare(const struct io_config *cfg1,
+                       const struct io_config *cfg2) {
+  return (cfg1->dir == cfg2->dir) && (cfg1->out == cfg2->out) &&
+         (cfg1->pupd_resistor == cfg2->pupd_resistor) &&
+         (cfg1->select == cfg2->select);
+}
+
 void io_set_select(io_e io, io_select_e select) {
   const uint8_t port = io_port(io);
   const uint8_t pin = io_pin_bit(io);

--- a/src/drivers/io.c
+++ b/src/drivers/io.c
@@ -1,6 +1,7 @@
 #include "drivers/io.h"
 #include "common/defines.h"
 
+#include <assert.h>
 #include <msp430.h>
 #include <stdint.h>
 
@@ -11,10 +12,14 @@
 #define IO_INTERRUPT_PORT_CNT (2u)
 
 /* To extract port and pin bit from enum io_generic_e (io_e).
- * Enums are represented as 16-bit by default on MSP430, so given
- * that the pins are ordered in increasing order(see io_generic_e),
- * and that there are 2 ports and 8 pins, the enum value can be viewed as:
- * [Zeros (11-bits) | Port (2-bits) | Pin(3-bits)] */
+ * With complier flag "-fshort-enums", the enums are represented
+ * as a single byte(8-bit), so given that the pins are ordered
+ * in increasing order(see io_generic_e), and that there are
+ * 2 ports and 8 pins, the enum value can be viewed as:
+ * [Zeros (3-bits) | Port (2-bits) | Pin(3-bits)] */
+
+static_assert(sizeof(io_generic_e) == 1,
+              "Unexpected size, -fshort-enums missing?");
 
 #define IO_PORT_OFFSET (3u)
 #define IO_PORT_MASK (0x3u << IO_PORT_OFFSET)

--- a/src/drivers/io.h
+++ b/src/drivers/io.h
@@ -1,6 +1,8 @@
 #ifndef IO_H
 #define IO_H
 
+#include <stdbool.h>
+
 /* IO pins handling including pinmapping,initialization, and configuration.
  * This wraps the more crude register defines provided in the headers from
  * Texas instrument */
@@ -94,6 +96,10 @@ struct io_config {
 void io_init(void);
 
 void io_configure(io_e io, const struct io_config *config);
+
+void io_get_current_config(io_e io, struct io_config *current_config);
+bool io_config_compare(const struct io_config *cfg1,
+                       const struct io_config *cfg2);
 
 void io_set_select(io_e io, io_select_e select);
 void io_set_direction(io_e io, io_dir_e direction);

--- a/src/drivers/led.c
+++ b/src/drivers/led.c
@@ -1,0 +1,35 @@
+#include "drivers/led.h"
+#include "common/assert_handler.h"
+#include "common/defines.h"
+#include "drivers/io.h"
+#include <stdbool.h>
+
+// Expected led configurations
+static const struct io_config led_config = {
+    .select = IO_SELECT_GPIO,
+    .pupd_resistor = IO_PUPD_DISABLED,
+    .dir = IO_DIR_OUTPUT,
+    .out = IO_OUT_LOW,
+};
+
+static bool initialized = false;
+
+void led_init(void) {
+  ASSERT(!initialized);
+  struct io_config current_config;
+  io_get_current_config(IO_TEST_LED, &current_config);
+  ASSERT(io_config_compare(&led_config, &current_config));
+
+  initialized = true;
+}
+
+void led_set(led_e led, led_state_e state) {
+
+  ASSERT(initialized);
+  const io_out_e out = (state == LED_STATE_ON) ? IO_OUT_HIGH : IO_OUT_LOW;
+  switch (led) {
+  case LED_TEST:
+    io_set_out(IO_TEST_LED, out);
+    break;
+  }
+}

--- a/src/drivers/led.h
+++ b/src/drivers/led.h
@@ -1,0 +1,16 @@
+#ifndef LED_H
+
+// A simple driver for controlling GPIOs with LEDs connected to them.
+typedef enum {
+  LED_TEST,
+} led_e;
+
+typedef enum {
+  LED_STATE_OFF,
+  LED_STATE_ON,
+} led_state_e;
+
+void led_init(void);
+void led_set(led_e led, led_state_e state);
+
+#endif // LED_H

--- a/src/main.c
+++ b/src/main.c
@@ -1,28 +1,36 @@
+#include "common/assert_handler.h"
+#include "common/defines.h"
 #include "drivers/io.h"
+#include "drivers/led.h"
 #include "drivers/mcu_init.h"
 #include <msp430.h>
 
 static void test_setup(void) { mcu_init(); }
 
+/*
+static void test_assert(void) {
+  test_setup();
+  ASSERT(0);
+}
+*/
+
 static void test_blink_led(void) {
   test_setup();
+  led_init();
+  // led_init(); // To check whether the assert_handler triggers or not
 
-  const struct io_config led_config = {.dir = IO_DIR_OUTPUT,
-                                       .select = IO_SELECT_GPIO,
-                                       .pupd_resistor = IO_PUPD_DISABLED,
-                                       .out = IO_OUT_LOW};
+  led_state_e led_state = LED_STATE_OFF;
 
-  io_configure(IO_TEST_LED, &led_config);
-  io_out_e out = IO_OUT_LOW;
   while (1) {
-    out = (out == IO_OUT_LOW) ? IO_OUT_HIGH : IO_OUT_LOW;
-    io_set_out(IO_TEST_LED, out);
-    __delay_cycles(250000); // 250ms
+    led_state = (led_state == LED_STATE_OFF) ? LED_STATE_ON : LED_STATE_OFF;
+    led_set(LED_TEST, led_state);
+    BUSY_WAIT_ms(1000); // 1 sec delay
   }
 }
 
 int main(void) {
   //  WDTCTL = WDTPW + WDTHOLD;
   test_blink_led();
+  // test_assert();
   return 0;
 }


### PR DESCRIPTION
Create an assert handler suitable for microcontroller. Let it trigger a software breakpoint (if debugger is attached) and then enter an endless while loop blinking the test led. The handler will later be extended with console tracing and turning off the motors.

Also, implement a simple led driver to avoid having to interact with the IO functoins directly, but dont use this driver in assert handler to avoid it to being called recursively.

Finally, wrap the __delay_cycles_ms intrinsic in a new define macro BUSY_WAIT_ms that takes milliseconds (instead of cycles) as argument.