### PR TITLE
fix(build): handle test functions better

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,3 +16,6 @@ jobs:
       
       - name: Set TOOLS_PATH and run make
         run: TOOLS_PATH=/home/ubuntu/dev/tools make HW=LAUNCHPAD
+
+      - name: Set TOOLS_PATH for running TEST functions through bash scripts
+        run: TOOLS_PATH=/home/ubuntu/dev/tools tools/build_tests.sh

--- a/src/common/defines.h
+++ b/src/common/defines.h
@@ -2,6 +2,7 @@
 #define DEFINES_H
 
 #define UNUSED(x) (void)(x)
+#define SUPPRESS_UNUSED __attribute__((unused))
 #define ARRAY_SIZE(array) (sizeof(array) / sizeof(array[0]))
 
 // Clock rate calculation when it is set to default 1MHZ

--- a/src/main.c
+++ b/src/main.c
@@ -1,36 +1,6 @@
 #include "common/assert_handler.h"
-#include "common/defines.h"
-#include "drivers/io.h"
-#include "drivers/led.h"
-#include "drivers/mcu_init.h"
-#include <msp430.h>
-
-static void test_setup(void) { mcu_init(); }
-
-/*
-static void test_assert(void) {
-  test_setup();
-  ASSERT(0);
-}
-*/
-
-static void test_blink_led(void) {
-  test_setup();
-  led_init();
-  // led_init(); // To check whether the assert_handler triggers or not
-
-  led_state_e led_state = LED_STATE_OFF;
-
-  while (1) {
-    led_state = (led_state == LED_STATE_OFF) ? LED_STATE_ON : LED_STATE_OFF;
-    led_set(LED_TEST, led_state);
-    BUSY_WAIT_ms(1000); // 1 sec delay
-  }
-}
 
 int main(void) {
-  //  WDTCTL = WDTPW + WDTHOLD;
-  test_blink_led();
-  // test_assert();
+  ASSERT(0);
   return 0;
 }

--- a/src/test/test.c
+++ b/src/test/test.c
@@ -1,0 +1,134 @@
+#include "common/assert_handler.h"
+#include "common/defines.h"
+#include "drivers/io.h"
+#include "drivers/led.h"
+#include "drivers/mcu_init.h"
+#include <msp430.h>
+
+SUPPRESS_UNUSED
+static void test_setup(void) 
+{ 
+	mcu_init(); //Initializes the mcu
+}
+
+
+SUPPRESS_UNUSED
+static void test_assert(void) {
+  test_setup();
+  ASSERT(0);
+}
+
+
+SUPPRESS_UNUSED
+static void test_blink_led(void) {
+  test_setup();
+  led_init();
+  // led_init(); // To check whether the assert_handler triggers or not
+
+  led_state_e led_state = LED_STATE_OFF;
+
+  while (1) {
+    led_state = (led_state == LED_STATE_OFF) ? LED_STATE_ON : LED_STATE_OFF;
+    led_set(LED_TEST, led_state);
+    BUSY_WAIT_ms(1000); // 1 sec delay
+  }
+}
+
+
+//Configure all pins as output and then toggle them in a loop. Verify with logic analyzer.
+
+SUPPRESS_UNUSED
+static void test_launchpad_io_pins_output(void)
+{
+	test_setup();
+	const struct io_config output_config={ 
+		.select=IO_SELECT_GPIO,
+		.pupd_resistor=IO_PUPD_DISABLED,
+		.dir=IO_DIR_OUTPUT,
+		.out=IO_OUT_LOW};
+
+	//Configure all pins as output
+	for(io_generic_e io=IO_10;io<=IO_27;io++)
+	{
+		io_configure(io,&output_config);
+	}
+
+	while(1)
+	{
+
+		for(io_generic_e io=IO_10;io<=IO_27;io++)
+		{
+			io_set_out(io,IO_OUT_HIGH);
+			BUSY_WAIT_ms(10);
+			io_set_out(io,IO_OUT_LOW);
+		}
+	}
+}
+
+
+/*Configure all pins except one pin(pin 1.0) as input with internal pull-up resistors.
+ * Configure the exception(pin 1.0) as output to control an LED. Verify by pulling 
+ * each pin down in increasing order with an external pull-down resistor. LED state changes 
+ * when the right pin is pulled down. Once all pins have verified OK, the LED blinks repeatedly.
+ *
+ * Note, The pins are configured with internal pull-up resitors (instead of pull-down) 
+ * because some pins on the LAUNCHPAD are already pulled up by external circuitry.
+ */
+
+SUPPRESS_UNUSED
+static void test_launchpad_io_pins_input(void)
+{
+	test_setup();
+	led_init();
+	const struct io_config input_config={
+		.select=IO_SELECT_GPIO,
+		.pupd_resistor=IO_PUPD_ENABLED,
+		.dir=IO_DIR_INPUT,
+		.out=IO_OUT_HIGH	//Pull-up
+	};
+
+	//Configure all pins as input
+	for(io_generic_e io=IO_10;io<=IO_27;io++)
+	{
+		io_configure(io,&input_config);
+	}
+
+	for(io_generic_e io=IO_10;io<=IO_27;io++)
+	{
+		if(io==(io_generic_e)IO_TEST_LED)
+		{
+			continue;
+		}
+		led_set(LED_TEST,LED_STATE_ON);
+		
+		//Wait for user to pull the pin low
+		
+		while(io_get_input(io)==IO_IN_HIGH)
+		{
+			BUSY_WAIT_ms(100);
+		}
+		led_set(LED_TEST,LED_STATE_OFF);
+
+		//Wait for user to disconnect
+
+		while(io_get_input(io)==IO_IN_LOW)
+		{
+			BUSY_WAIT_ms(100);
+		}
+	}
+
+	//Blink LED when test is done
+	while(1)
+	{
+		led_set(LED_TEST,LED_STATE_ON);
+		BUSY_WAIT_ms(500);
+		led_set(LED_TEST,LED_STATE_OFF);
+		BUSY_WAIT_ms(2000);
+	}
+}
+
+int main()
+{
+	TEST();
+	ASSERT(0);
+}

--- a/tools/build_tests.sh
+++ b/tools/build_tests.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+#This script is used by CI to build all test functions
+
+
+SCRIPT_DIR=$(dirname "$0")
+TEST_FUNCTIONS=$(cat src/test/test.c | grep -P '(?<=void )test_.+(?=\()' -o)
+for test_function in $TEST_FUNCTIONS
+do
+	make HW=LAUNCHPAD TEST=$test_function
+done


### PR DESCRIPTION
Currently, I just build the test function I want to run and comment out the rest. This is not a good way to do it. Improve on it by moving the test functions to a seperate file and pass the test function as an argument to make instead. Note, these are just "scratch" functions I use to test isolated parts of the code during development.