### PR TITLE
build: add two makefile rules for analyzing flash space used.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -49,6 +49,8 @@ RM=rm
 DEBUG = LD_LIBRARY_PATH=$(DEBUG_DRIVERS_DIR) $(DEBUG_BIN_DIR)/mspdebug
 CPPCHECK = cppcheck
 FORMAT = clang-format-12
+SIZE=$(MSPGCC_BIN_DIR)/msp430-elf-size
+READELF=$(MSPGCC_BIN_DIR)/msp430-elf-readelf
 
 #Files
 TARGET = $(BUILD_DIR)/bin/$(TARGET_HW)/$(TARGET_NAME)
@@ -141,7 +143,7 @@ $(OBJ_DIR)/%.o: %.c
 
 #Phonies
 
-.PHONY: all clean flash cppcheck format
+.PHONY: all clean flash cppcheck format size symbols
 
 all: $(TARGET)
 
@@ -155,3 +157,11 @@ cppcheck:
 	@$(CPPCHECK) $(CPPCHECK_FLAGS) $(SOURCES)
 format:
 	@$(FORMAT) -i $(SOURCES) $(HEADERS)
+
+size: $(TARGET)
+	@$(SIZE) $(TARGET)
+
+symbols: $(TARGET)
+	#List symbols table sorted by size
+	@$(READELF) -s $(TARGET) | sort -n -k3
+


### PR DESCRIPTION
MSP430F5529 has 128KB of flash, so care must be taken when programming it as to not run out of this small space. The GCC-toolchain has several tools for seeing how much space the code occupies, add these as rules to the Makefile.

While at it, remove "inline" from some of the IO functions because they apparently occupy more space as inlined. May lead to more CPU cycles, but insignificant, and prefer space over speed in this case.