### PR TITLE
feat(io): handle IO interrupts

### DIFF
--- a/src/common/defines.h
+++ b/src/common/defines.h
@@ -5,6 +5,8 @@
 #define SUPPRESS_UNUSED __attribute__((unused))
 #define ARRAY_SIZE(array) (sizeof(array) / sizeof(array[0]))
 
+#define INTERRUPT_FUNCTION(vector) void __attribute__((interrupt(vector)))
+
 // Clock rate calculation when it is set to default 1MHZ
 #define CYCLES_1MHZ (1000000u)
 #define ms_TO_CYCLES(ms) ((CYCLES_1MHZ / 1000u) * ms)

--- a/src/drivers/io.h
+++ b/src/drivers/io.h
@@ -82,6 +82,11 @@ typedef enum {
   IO_IN_HIGH,
 } io_in_e; // input register
 
+typedef enum {
+  IO_TRIGGER_RISING,
+  IO_TRIGGER_FALLING,
+} io_trigger_e;
+
 // TODO: structs
 
 struct io_config {
@@ -106,5 +111,12 @@ void io_set_direction(io_e io, io_dir_e direction);
 void io_set_pupd(io_e io, io_pupd_e pupd_resistor);
 void io_set_out(io_e io, io_out_e out);
 io_in_e io_get_input(io_e io); // the input register function returns a value
+
+// INTERRUPTS
+typedef void (*isr_function)(void); // function pointer of type void
+void io_configure_interrupt(io_e io, io_trigger_e trigger, isr_function isr);
+void io_deconfigure_interrupt(io_e io);
+void io_enable_interrupt(io_e io);
+void io_disable_interrupt(io_e io);
 
 #endif // IO_H

--- a/src/drivers/mcu_init.c
+++ b/src/drivers/mcu_init.c
@@ -11,4 +11,7 @@ void mcu_init(void) {
   // Must stop the watchdog first before anything else
   watchdog_stop();
   io_init();
+
+  // Enables the Interrupt globally
+  _enable_interrupts();
 }

--- a/src/test/test.c
+++ b/src/test/test.c
@@ -127,6 +127,44 @@ static void test_launchpad_io_pins_input(void)
 	}
 }
 
+
+SUPPRESS_UNUSED
+static void io_12_isr(void)
+{
+	led_set(LED_TEST, LED_STATE_ON);
+}
+
+SUPPRESS_UNUSED
+static void io_22_isr(void)
+{
+	led_set(LED_TEST, LED_STATE_OFF);
+}
+
+
+
+//TESTING INTERRUPT
+SUPPRESS_UNUSED
+static void test_io_interrupt(void)
+{
+	test_setup();
+	const struct io_config input_config = {
+		.select = IO_SELECT_GPIO,
+		.pupd_resistor = IO_PUPD_ENABLED,
+		.dir = IO_DIR_INPUT,
+		.out = IO_OUT_HIGH //pull-up
+	};
+
+	io_configure(IO_12, &input_config);
+	io_configure(IO_22, &input_config);
+	led_init();
+	io_configure_interrupt(IO_12, IO_TRIGGER_FALLING, io_12_isr);
+	io_configure_interrupt(IO_22, IO_TRIGGER_FALLING, io_22_isr);
+	io_enable_interrupt(IO_12);
+	io_enable_interrupt(IO_22);
+	while(1);
+}
+
+
 int main()
 {
 	TEST();


### PR DESCRIPTION
Add functions for configuring IO interrupts. Make it possible to pass and interrupt service routine (ISR) as an arguement, and have that be called inside the corresponding port interrupt function. Access the interrupt related registers in the same way as the rest of the IO registers.