### PR TITLE
feat(drivers): UART driver and ring buffer

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -57,11 +57,13 @@ TARGET = $(BUILD_DIR)/bin/$(TARGET_HW)/$(TARGET_NAME)
 
 SOURCES_WITH_HEADERS = \
 					   src/common/assert_handler.c \
+					   src/common/ring_buffer.c \
 					   src/app/drive.c \
 					   src/drivers/led.c \
 					   src/app/enemy.c \
 					   src/drivers/io.c \
 					   src/drivers/mcu_init.c \
+					   src/drivers/uart.c \
 
 
 #SOURCES_WITH_HEADERS = \

--- a/src/common/assert_handler.h
+++ b/src/common/assert_handler.h
@@ -5,7 +5,15 @@
     if (!(expression)) {                                                       \
       assert_handler();                                                        \
     }                                                                          \
-  } while (0);
+  } while (0)
+
+#define ASSERT_INTERRUPT(expression)                                           \
+  do {                                                                         \
+    if (!(expression)) {                                                       \
+      while (1)                                                                \
+        ;                                                                      \
+    }                                                                          \
+    while (0)
 
 void assert_handler(void);
 

--- a/src/common/ring_buffer.c
+++ b/src/common/ring_buffer.c
@@ -1,0 +1,52 @@
+#include "common/ring_buffer.h"
+
+// This function adds an element to the ring buffer.
+void ring_buffer_put(struct ring_buffer *rb, uint8_t data) {
+  rb->buffer[rb->head] = data;
+  rb->head++;
+
+  /* To check whether the head is larger than the size of underlying buffer,
+   * if yes then it has to over-wrap by pointing to the first index of the
+   * underlying buffer.*/
+  if (rb->head == rb->size) {
+    rb->head = 0;
+  }
+}
+
+// Retrive an element from the ring buffer
+uint8_t ring_buffer_get(struct ring_buffer *rb) {
+  const uint8_t data = rb->buffer[rb->tail];
+  rb->tail++;
+
+  /* To check whether the tail is larger than the size of underlying buffer,
+   * if yes then it has to over-wrap by pointing to the first index of the
+   * underlying buffer.*/
+  if (rb->tail == rb->size) {
+    rb->tail = 0;
+  }
+  return data;
+}
+
+// Gets the elemnt of the ring buffer by peeking at the value.
+uint8_t ring_buffer_peek(const struct ring_buffer *rb) {
+  return rb->buffer[rb->tail];
+}
+
+// To check whether the ring buffer is empty.
+bool ring_buffer_empty(const struct ring_buffer *rb) {
+  /* Adding characters will increment the head, while
+   * fetching the characters will increment the tail,
+   * when tail becomes equal to head, then the buffer is empty.
+   */
+  return rb->head == rb->tail;
+}
+
+// To check whether the ring buffer is full.
+bool ring_buffer_full(const struct ring_buffer *rb) {
+  uint8_t idx_after_head = rb->head + 1;
+
+  if (idx_after_head == rb->size) {
+    idx_after_head = 0;
+  }
+  return idx_after_head == rb->tail;
+}

--- a/src/common/ring_buffer.h
+++ b/src/common/ring_buffer.h
@@ -1,0 +1,35 @@
+#ifndef RING_BUFFER_H_
+#define RING_BUFFER_H_
+
+#include <stdbool.h>
+#include <stdint.h>
+
+struct ring_buffer {
+  uint8_t *buffer; // pointer to the underlying buffer
+  uint8_t size;
+  uint8_t head;
+  uint8_t tail;
+};
+
+/*Caller must check if full.
+ * This function adds an element to the ring buffer.
+ */
+void ring_buffer_put(struct ring_buffer *rb, uint8_t data);
+
+/*Caller must check if empty.
+ * Retrive an element from the ring buffer.
+ */
+uint8_t ring_buffer_get(struct ring_buffer *rb);
+
+/*Caller must check if empty.
+ * Gets the elemnt of the ring buffer by peeking at the value.
+ */
+uint8_t ring_buffer_peek(const struct ring_buffer *rb);
+
+// To check whether the ring buffer is empty.
+bool ring_buffer_empty(const struct ring_buffer *rb);
+
+// To check whether the ring buffer is full.
+bool ring_buffer_full(const struct ring_buffer *rb);
+
+#endif /* RING_BUFFER_H_ */

--- a/src/drivers/uart.c
+++ b/src/drivers/uart.c
@@ -1,0 +1,189 @@
+#include "drivers/uart.h"
+#include "common/assert_handler.h"
+#include "common/ring_buffer.h"
+#include <assert.h>
+#include <msp430.h>
+#include <stdint.h>
+
+#define UART_BUFFER_SIZE (16)
+
+static uint8_t buffer[UART_BUFFER_SIZE];
+static struct ring_buffer tx_buffer = {.buffer = buffer,
+                                       .size = sizeof(buffer)};
+
+/* Calcualte the integer and fractional part of the divisor
+ * N = (Clock source / Desired baudrate)
+ * for Low-frequency baud rate mode.
+ *
+ * These are used to configure the desired baudrate.
+ *
+ * For more info on corresponding transmission error
+ * for common values, refer the table provided in the
+ * msp430x5xx family user guide.
+ */
+
+#define SMCLK (1000000u)
+#define BRCLK (SMCLK)
+#define UART_BAUD_RATE (115200u)
+
+static_assert(
+    UART_BAUD_RATE < (BRCLK / 3.0f),
+    "Baudrate must be smaller than 1/3 of input clock in Low-Frequency Mode");
+
+#define UART_DIVISOR ((float)BRCLK / UART_BAUD_RATE)
+static_assert(UART_DIVISOR < 0xFFFFu, "Sanity check divisor fits in 16-bit");
+
+#define UART_DIVISOR_INT_16BIT ((uint16_t)UART_DIVISOR)
+#define UART_DIVISOR_INT_LOW_BYTE (UART_DIVISOR_INT_16BIT & 0xFF)
+#define UART_DIVISOR_INT_HIGH_BYTE (UART_DIVISOR_INT_16BIT >> 8)
+
+#define UART_DIVISOR_FRACTIONAL (UART_DIVISOR - UART_DIVISOR_INT_16BIT)
+
+#define UART_UCBRS ((uint8_t)(8 * UART_DIVISOR_FRACTIONAL))
+static_assert(UART_UCBRS < 8,
+              "Sanity check second modulation stage value fits in 3-bit");
+
+#define UART_UCBRF (0)
+#define UART_UCOS16 (0)
+
+/* Clear the Transmit Interrupt flag and
+ * inline function is used to avoid function call-overhead. */
+static inline void uart_tx_clear_interrupt(void) { UCA0IFG &= ~UCTXIFG; }
+
+static inline void uart_tx_enable_interrupt(void) {
+  // Enable the TX interrupt
+  UCA0IE |= UCTXIE;
+}
+
+static inline void uart_tx_disable_interrupt(void) {
+  // Disable the TX interrupt
+  UCA0IE &= ~UCTXIE;
+}
+
+static void uart_tx_start(void) {
+  // Check whether the buffer is empty, if not, then transmit the data remaining
+  // in the buffer until it is empty.
+
+  if (!ring_buffer_empty(&tx_buffer)) {
+    UCA0TXBUF = ring_buffer_peek(&tx_buffer);
+  }
+}
+
+__attribute__((interrupt(USCI_A0_VECTOR))) void USCI_A0_ISR(void) {
+
+  switch (__even_in_range(UCA0IV, 4)) {
+  case 0:
+    break; // No interrupt
+  case 2:
+    break; // RX interrupt (ignored)
+  case 4:  // TX interrupt
+    if (ring_buffer_empty(&tx_buffer)) {
+      // Add and assert here
+      while (1)
+        ;
+    }
+
+    // Remove the transmitted data byte from the buffer
+    ring_buffer_get(&tx_buffer);
+
+    // Clear interrupt here to avoid accidently clearing interrupt for next
+    // transmission
+    uart_tx_clear_interrupt();
+
+    // Check whether the buffer is empty, if not, then transmit the data
+    // remaining in the buffer until it is empty.
+    if (!ring_buffer_empty(&tx_buffer)) {
+      uart_tx_start();
+    }
+    break;
+  default:
+    break;
+  }
+}
+
+// This function will initialize the UART peripheral
+void uart_init(void) {
+  /* Reset module. It stays in reset until cleared. The module should be in
+   * reset condition while configured, according to msp430x5xx family user
+   * guide.
+   */
+  UCA0CTL1 |= UCSWRST;
+
+  /*Use default (data word length 8 bits, 1 stop bit, no parity bit)
+   * [ start (1 bit) | data (8 bits) | stop (1 bit) ]
+   */
+  UCA0CTL0 = 0;
+
+  // Set SMCLK as clock source
+  UCA0CTL1 |= UCSSEL_2;
+
+  // Set clock prescaler  to the integer part of divisor N.
+  UCA0BR0 = UART_DIVISOR_INT_LOW_BYTE;
+  UCA0BR1 = UART_DIVISOR_INT_HIGH_BYTE;
+
+  /* Set modulation to account for fractional part of divisor N.
+   * UCA0MCTL = [UCBRF (4-bits) | UCBRS(3-bits) | UC0S16(1-bit)]
+   */
+  UCA0MCTL = (UART_UCBRF << 4) + (UART_UCBRS << 1) + UART_UCOS16;
+
+  // Clear reset to release module for operation.
+  UCA0CTL1 &= ~UCSWRST;
+
+  // Interrupt triggers when TX buffer is empty, which it is after boot, so need
+  // to clear it here.
+  uart_tx_clear_interrupt();
+
+  // Enable the TX interrupt
+  uart_tx_enable_interrupt();
+}
+
+// This function will send a single character through polling method
+void uart_putchar_polling(char c) {
+  // Wait for any ongoing transmission to finish.
+  // Check for USCI A0 Interrupt flag register i.e. UCA0IFG which contains TX
+  // and RX interrupt buffer flags
+  while (!(UCA0IFG & UCTXIFG))
+    ;
+
+  UCA0TXBUF = c;
+
+  // Carriage return(\r) after line feed(\n) for proper new line.
+  if (c == '\n') {
+    uart_putchar_polling('\r');
+  }
+}
+
+// This function will send characters through Interrupt method
+void uart_putchar_interrupt(char c) {
+  // Poll is full
+  while (ring_buffer_full(&tx_buffer))
+    ;
+
+  // Disable the tx interrupt before starting the transmission
+  uart_tx_disable_interrupt();
+
+  // Check if there is any ongoing transmission.
+  const bool tx_ongoing = !ring_buffer_empty(&tx_buffer);
+
+  ring_buffer_put(&tx_buffer, c);
+
+  if (!tx_ongoing) {
+    uart_tx_start();
+  }
+
+  uart_tx_enable_interrupt();
+
+  // Carriage return(\r) after line feed(\n) for proper new line.
+  if (c == '\n') {
+    uart_putchar_interrupt('\r');
+  }
+}
+
+// To print an entire string of characters
+void uart_print_interrupt(const char *string) {
+  int i = 0;
+  while (string[i] != '\0') {
+    uart_putchar_interrupt(string[i]);
+    i++;
+  }
+}

--- a/src/drivers/uart.h
+++ b/src/drivers/uart.h
@@ -1,0 +1,16 @@
+#ifndef UART_H_
+#define UART_H_
+
+// This will initialize the UART peripheral
+void uart_init(void);
+
+// This function will send a single character through polling method
+void uart_putchar_polling(char c);
+
+// This function will send characters through Interrupt method
+void uart_putchar_interrupt(char c);
+
+// To print an entire string of characters
+void uart_print_interrupt(const char *string);
+
+#endif /* UART_H_ */

--- a/src/test/test.c
+++ b/src/test/test.c
@@ -3,6 +3,7 @@
 #include "drivers/io.h"
 #include "drivers/led.h"
 #include "drivers/mcu_init.h"
+#include "drivers/uart.h"
 #include <msp430.h>
 
 SUPPRESS_UNUSED
@@ -164,6 +165,19 @@ static void test_io_interrupt(void)
 	while(1);
 }
 
+
+//TESTING UART
+SUPPRESS_UNUSED
+static void test_uart(void)
+{
+	test_setup();
+	uart_init();
+	while(1)
+	{
+		uart_print_interrupt("Sumo Robot\n");
+		BUSY_WAIT_ms(100);
+	}
+}
 
 int main()
 {


### PR DESCRIPTION
Add a driver for the UART peripheral that can transmit individual characters. Make it interrupt driven and put the characters in a ring buffer that the interrupt can feed from. This is going to be used to implement tracing (printf) in the future.

Also, write the calibrated clock values correctly.

This was tested by connecting the LAUNCPAD to a PC via a USB-to-UART bridge and using the command:
picocom -b 115200 /dev/ttyUSB0