### PR TITLE
Feat trace

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,6 +7,8 @@ jobs:
     steps:
       - name: Checkout the repository
         uses: actions/checkout@v3
+        with:
+          submodules: "true"
       
       - name: Formatting the code
         run: make format && git diff --quiet

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "external/printf"]
 	path = external/printf
-	url = https://github.com/mpaland/printf.git
+	url = https://github.com/mpaland/printf

--- a/Makefile
+++ b/Makefile
@@ -51,6 +51,8 @@ CPPCHECK = cppcheck
 FORMAT = clang-format-12
 SIZE=$(MSPGCC_BIN_DIR)/msp430-elf-size
 READELF=$(MSPGCC_BIN_DIR)/msp430-elf-readelf
+ADDR2LINE = $(MSPGCC_BIN_DIR)/msp430-elf-addr2line
+
 
 #Files
 TARGET = $(BUILD_DIR)/bin/$(TARGET_HW)/$(TARGET_NAME)
@@ -153,7 +155,7 @@ $(OBJ_DIR)/%.o: %.c
 
 #Phonies
 
-.PHONY: all clean flash cppcheck format size symbols
+.PHONY: all clean flash cppcheck format size symbols addr2line
 
 all: $(TARGET)
 
@@ -175,3 +177,5 @@ symbols: $(TARGET)
 	#List symbols table sorted by size
 	@$(READELF) -s $(TARGET) | sort -n -k3
 
+addr2line: $(TARGET)
+	@$(ADDR2LINE) -e $(TARGET) $(ADDR)

--- a/Makefile
+++ b/Makefile
@@ -39,7 +39,7 @@ LIB_DIRS = $(MSPGCC_INCLUDE_DIR)
 INCLUDE_DIRS = $(MSPGCC_INCLUDE_DIR) \
 	       ./src \
 	       ./external/ \
-	       ./external/printf
+	       ./
 
 
 
@@ -64,6 +64,7 @@ SOURCES_WITH_HEADERS = \
 					   src/drivers/io.c \
 					   src/drivers/mcu_init.c \
 					   src/drivers/uart.c \
+					   external/printf/printf.c \
 
 
 #SOURCES_WITH_HEADERS = \
@@ -108,6 +109,8 @@ TEST_DEFINE = $(addprefix -DTEST=,$(TEST))
 DEFINES = \
 		  $(HW_DEFINE) \
 		  $(TEST_DEFINE) \
+		  -DPRINTF_INCLUDE_CONFIG_H \
+
 
 #Static Analysis
 ##Don't check the msp430 helper headers (they have a lot of ifdefs)

--- a/Makefile
+++ b/Makefile
@@ -58,6 +58,7 @@ TARGET = $(BUILD_DIR)/bin/$(TARGET_HW)/$(TARGET_NAME)
 SOURCES_WITH_HEADERS = \
 					   src/common/assert_handler.c \
 					   src/common/ring_buffer.c \
+					   src/common/trace.c \
 					   src/app/drive.c \
 					   src/drivers/led.c \
 					   src/app/enemy.c \
@@ -114,8 +115,12 @@ DEFINES = \
 
 #Static Analysis
 ##Don't check the msp430 helper headers (they have a lot of ifdefs)
-CPPCHECK_INCLUDES = ./src
-CPPCHECK_IGNORE = external/printf
+CPPCHECK_INCLUDES = ./src ./
+IGNORE_FILES_FORMAT_CPPCHECK = \
+							   external/printf/printf.h \
+							   external/printf/printf.c
+SOURCES_FORMAT_CPPCHECK = $(filter-out $(IGNORE_FILES_FORMAT_CPPCHECK),$(SOURCES))
+HEADERS_FORMAT = $(filter-out $(IGNORE_FILES_FORMAT_CPPCHECK),$(HEADERS))
 CPPCHECK_FLAGS = \
 		 --quiet --enable=all --error-exitcode=1 \
 		 --inline-suppr \
@@ -124,7 +129,7 @@ CPPCHECK_FLAGS = \
 		 --suppress=unmatchedSuppression \
 		 --suppress=unusedFunction \
 		 $(addprefix -I,$(CPPCHECK_INCLUDES)) \
-		 $(ADDPREFIX -i,$(CPPCHECK_IGNORE))
+
 
 #Flags
 MCU = msp430f5529
@@ -159,9 +164,9 @@ flash: $(TARGET)
 	@$(DEBUG) tilib "prog $(TARGET)"
 
 cppcheck:
-	@$(CPPCHECK) $(CPPCHECK_FLAGS) $(SOURCES)
+	@$(CPPCHECK) $(CPPCHECK_FLAGS) $(SOURCES_FORMAT_CPPCHECK)
 format:
-	@$(FORMAT) -i $(SOURCES) $(HEADERS)
+	@$(FORMAT) -i $(SOURCES_FORMAT_CPPCHECK) $(HEADERS_FORMAT)
 
 size: $(TARGET)
 	@$(SIZE) $(TARGET)

--- a/external/printf_config.h
+++ b/external/printf_config.h
@@ -1,0 +1,13 @@
+#ifndef PRINTF_CONFIG_H
+#define PRINTF_CONFIG_H
+
+/* Configuration file for the mpaland printf implementation (see external/printf).
+ * PRINTF_INCLUDE_CONFIG_H must be defined as a compiler switch for this to be picked up */
+
+// Disable everything not used to reduce flash usage
+#define PRINTF_DISABLE_SUPPORT_LONG_LONG
+#define PRINTF_DISABLE_SUPPORT_PTRDIFF_T
+#define PRINTF_DISABLE_SUPPORT_EXPONENTIAL
+#define PRINTF_DISABLE_SUPPORT_FLOAT
+
+#endif // PRINTF_CONFIG_H

--- a/external/printf_config.h
+++ b/external/printf_config.h
@@ -1,5 +1,5 @@
-#ifndef PRINTF_CONFIG_H
-#define PRINTF_CONFIG_H
+#ifndef PRINTF_INCLUDE_CONFIG_H
+#define PRINTF_INCLUDE_CONFIG_H
 
 /* Configuration file for the mpaland printf implementation (see external/printf).
  * PRINTF_INCLUDE_CONFIG_H must be defined as a compiler switch for this to be picked up */
@@ -10,4 +10,4 @@
 #define PRINTF_DISABLE_SUPPORT_EXPONENTIAL
 #define PRINTF_DISABLE_SUPPORT_FLOAT
 
-#endif // PRINTF_CONFIG_H
+#endif // PRINTF_INCLUDE_CONFIG_H

--- a/src/common/assert_handler.h
+++ b/src/common/assert_handler.h
@@ -1,19 +1,19 @@
 #ifndef ASSERT_HANDLER_H
 
-#define ASSERT(expression)                                                     \
-  do {                                                                         \
-    if (!(expression)) {                                                       \
-      assert_handler();                                                        \
-    }                                                                          \
-  } while (0)
+#define ASSERT(expression)                          \
+	do {											\
+		if (!(expression)) {						\
+			assert_handler();						\
+		}											\
+	} while (0)
 
-#define ASSERT_INTERRUPT(expression)                                           \
-  do {                                                                         \
-    if (!(expression)) {                                                       \
-      while (1)                                                                \
-        ;                                                                      \
-    }                                                                          \
-    while (0)
+
+#define ASSERT_INTERRUPT(expression)				\
+	do {											\
+		if (!(expression)) {						\
+			while (1);								\
+		}											\
+	}while (0)
 
 void assert_handler(void);
 

--- a/src/common/assert_handler.h
+++ b/src/common/assert_handler.h
@@ -1,9 +1,15 @@
 #ifndef ASSERT_HANDLER_H
 
+#include <stdint.h>
+
+// Assert implementation suitable for microcontroller
+
 #define ASSERT(expression)                                                     \
   do {                                                                         \
     if (!(expression)) {                                                       \
-      assert_handler();                                                        \
+      uint16_t pc;                                                             \
+      asm volatile("mov pc, %0" : "=r"(pc));                                   \
+      assert_handler(pc);                                                      \
     }                                                                          \
   } while (0)
 
@@ -15,6 +21,6 @@
     }                                                                          \
   } while (0)
 
-void assert_handler(void);
+void assert_handler(uint16_t program_counter);
 
 #endif

--- a/src/common/assert_handler.h
+++ b/src/common/assert_handler.h
@@ -1,19 +1,19 @@
 #ifndef ASSERT_HANDLER_H
 
-#define ASSERT(expression)                          \
-	do {											\
-		if (!(expression)) {						\
-			assert_handler();						\
-		}											\
-	} while (0)
+#define ASSERT(expression)                                                     \
+  do {                                                                         \
+    if (!(expression)) {                                                       \
+      assert_handler();                                                        \
+    }                                                                          \
+  } while (0)
 
-
-#define ASSERT_INTERRUPT(expression)				\
-	do {											\
-		if (!(expression)) {						\
-			while (1);								\
-		}											\
-	}while (0)
+#define ASSERT_INTERRUPT(expression)                                           \
+  do {                                                                         \
+    if (!(expression)) {                                                       \
+      while (1)                                                                \
+        ;                                                                      \
+    }                                                                          \
+  } while (0)
 
 void assert_handler(void);
 

--- a/src/common/trace.c
+++ b/src/common/trace.c
@@ -1,0 +1,24 @@
+#ifndef DISABLE_TRACE
+#include "common/trace.h"
+#include "common/assert_handler.h"
+#include "drivers/uart.h"
+#include "external/printf/printf.h"
+#include <stdbool.h>
+
+static bool initialized = false;
+
+void trace_init(void) {
+  ASSERT(!initialized);
+  uart_init();
+  initialized = true;
+}
+
+void trace(const char *format, ...) {
+  ASSERT(initialized);
+  va_list args;
+  va_start(args, format);
+  vprintf(format, args);
+  va_end(args);
+}
+
+#endif // DISABLE_TRACE

--- a/src/common/trace.h
+++ b/src/common/trace.h
@@ -1,0 +1,15 @@
+#ifndef TRACE_H
+#define TRACE_H
+
+#define TRACE(fmt, ...)                                                        \
+  trace("%s:%d: " fmt "\n", __FILE__, __LINE__, ##__VA_ARGS__)
+
+#ifndef DISABLE_TRACE
+void trace_init(void);
+void trace(const char *format, ...);
+#else
+#define trace_init() ;
+#define trace(fmt, ...) ;
+#endif
+
+#endif // TRACE_H

--- a/src/drivers/io.c
+++ b/src/drivers/io.c
@@ -8,12 +8,13 @@
 #include <stdint.h>
 
 #if defined(LAUNCHPAD)
-#define IO_PORT_CNT (2u)
+
+#define IO_PORT_CNT (3u)
 #endif
 
 #define IO_PIN_CNT_PER_PORT (8u)
 
-#define IO_INTERRUPT_PORT_CNT (2u)
+#define IO_INTERRUPT_PORT_CNT (3u)
 
 /* To extract port and pin bit from enum io_generic_e (io_e).
  * With complier flag "-fshort-enums", the enums are represented
@@ -39,10 +40,7 @@ static inline uint8_t io_pin_idx(io_e io) { return io & IO_PIN_MASK; }
 
 static inline uint8_t io_pin_bit(io_e io) { return 1 << io_pin_idx(io); }
 
-typedef enum {
-  IO_PORT1,
-  IO_PORT2,
-} io_port_e;
+typedef enum { IO_PORT1, IO_PORT2, IO_PORT3 } io_port_e;
 
 /* TI's helper header (msp430.h) provides defines/variables for accessing the
  * registers, and the address of these are resolved during linking. For cleaner
@@ -51,11 +49,16 @@ typedef enum {
  * access them through array indexing. */
 
 #if defined(LAUNCHPAD)
-static volatile uint8_t *const port_dir_regs[IO_PORT_CNT] = {&P1DIR, &P2DIR};
-static volatile uint8_t *const port_ren_regs[IO_PORT_CNT] = {&P1REN, &P2REN};
-static volatile uint8_t *const port_out_regs[IO_PORT_CNT] = {&P1OUT, &P2OUT};
-static volatile uint8_t *const port_in_regs[IO_PORT_CNT] = {&P1IN, &P2IN};
-static volatile uint8_t *const port_sel1_regs[IO_PORT_CNT] = {&P1SEL, &P2SEL};
+static volatile uint8_t *const port_dir_regs[IO_PORT_CNT] = {&P1DIR, &P2DIR,
+                                                             &P3DIR};
+static volatile uint8_t *const port_ren_regs[IO_PORT_CNT] = {&P1REN, &P2REN,
+                                                             &P3REN};
+static volatile uint8_t *const port_out_regs[IO_PORT_CNT] = {&P1OUT, &P2OUT,
+                                                             &P3OUT};
+static volatile uint8_t *const port_in_regs[IO_PORT_CNT] = {&P1IN, &P2IN,
+                                                            &P3IN};
+static volatile uint8_t *const port_sel1_regs[IO_PORT_CNT] = {&P1SEL, &P2SEL,
+                                                              &P3SEL};
 // static volatile uint8_t *const port_sel2_regs[IO_PORT_CNT] = {&P1SEL2,
 // &P2SEL2};
 #endif

--- a/src/drivers/io.h
+++ b/src/drivers/io.h
@@ -30,6 +30,15 @@ typedef enum {
   IO_25,
   IO_26,
   IO_27,
+  IO_30,
+  IO_31,
+  IO_32,
+  IO_33,
+  IO_34,
+  IO_35,
+  IO_36,
+  IO_37,
+
 } io_generic_e;
 
 //clang-format on
@@ -38,8 +47,8 @@ typedef enum {
 #if defined(LAUNCHPAD)
 
   IO_TEST_LED = IO_10,
-  IO_UART_RXD = IO_12,
-  IO_UART_TXD = IO_13,
+  IO_UART_RXD = IO_34,
+  IO_UART_TXD = IO_33,
   IO_UNUSED_1 = IO_14,
   IO_UNUSED_2 = IO_15,
   IO_UNUSED_3 = IO_16,

--- a/src/drivers/uart.c
+++ b/src/drivers/uart.c
@@ -100,9 +100,7 @@ INTERRUPT_FUNCTION(USCI_A0_VECTOR) USCI_A0_ISR(void) {
   // the compiler might throw the error here.
 }
 
-static bool initialized = false;
-// This function will initialize the UART peripheral
-void uart_init(void) {
+static void uart_configure(void) {
   /* Reset module. It stays in reset until cleared. The module should be in
    * reset condition while configured, according to msp430x5xx family user
    * guide.
@@ -128,6 +126,15 @@ void uart_init(void) {
 
   // Clear reset to release module for operation.
   UCA0CTL1 &= ~UCSWRST;
+}
+
+static bool initialized = false;
+// This function will initialize the UART peripheral
+void uart_init(void) {
+
+  ASSERT(!initialized);
+
+  uart_configure();
 
   // Interrupt triggers when TX buffer is empty, which it is after boot, so need
   // to clear it here.
@@ -221,3 +228,17 @@ void uart_print_interrupt(const char *string) {
   }
 }
 */
+
+// FOR ASSERTION
+void uart_init_assert(void) {
+  uart_tx_disable_interrupt();
+  uart_configure();
+}
+
+void uart_trace_assert(const char *string) {
+  int i = 0;
+  while (string[i] != '\0') {
+    uart_putchar_polling(string[i]);
+    i++;
+  }
+}

--- a/src/drivers/uart.h
+++ b/src/drivers/uart.h
@@ -17,4 +17,10 @@ void uart_print_interrupt(const char *string);
 
 void _putchar(char c);
 
+// For ASSERTION
+// These 2 functions should ONLY called by ASSERT_HANDLER
+void uart_init_assert(void);
+
+void uart_trace_assert(const char *string);
+
 #endif /* UART_H_ */

--- a/src/drivers/uart.h
+++ b/src/drivers/uart.h
@@ -7,10 +7,14 @@ void uart_init(void);
 // This function will send a single character through polling method
 void uart_putchar_polling(char c);
 
+/*
 // This function will send characters through Interrupt method
 void uart_putchar_interrupt(char c);
 
 // To print an entire string of characters
 void uart_print_interrupt(const char *string);
+*/
+
+void _putchar(char c);
 
 #endif /* UART_H_ */

--- a/src/test/test.c
+++ b/src/test/test.c
@@ -5,8 +5,8 @@
 #include "drivers/mcu_init.h"
 #include "drivers/uart.h"
 #include <msp430.h>
-#include "external/printf/printf.h"
-
+//#include "external/printf/printf.h"
+#include "common/trace.h"
 
 SUPPRESS_UNUSED
 static void test_setup(void) 
@@ -177,11 +177,13 @@ static void test_uart(void)
 	while(1)
 	{
 		//uart_print_interrupt("Sumo Robot\n");
+		
 		_putchar('s');
 		_putchar('u');
 		_putchar('m');
 		_putchar('o');
 		_putchar('\n');
+		
 		BUSY_WAIT_ms(100);
 	}
 }
@@ -190,10 +192,16 @@ SUPPRESS_UNUSED
 static void test_trace(void)
 {
 	test_setup();
-	uart_init();
+	trace_init();
 	while(1)
 	{
-		printf("Sumo robot %d\n",2024);
+		//printf("Sumo robot %d\n",2024);
+		TRACE("sumo robot %d\n",2024);
+
+		/* TRACE working:
+		 * TRACE(...)-> trace()->printf->_putchar->uarttxbuf
+		 * */
+		BUSY_WAIT_ms(100);
 	}
 }
 

--- a/src/test/test.c
+++ b/src/test/test.c
@@ -5,6 +5,8 @@
 #include "drivers/mcu_init.h"
 #include "drivers/uart.h"
 #include <msp430.h>
+#include "external/printf/printf.h"
+
 
 SUPPRESS_UNUSED
 static void test_setup(void) 
@@ -174,8 +176,24 @@ static void test_uart(void)
 	uart_init();
 	while(1)
 	{
-		uart_print_interrupt("Sumo Robot\n");
+		//uart_print_interrupt("Sumo Robot\n");
+		_putchar('s');
+		_putchar('u');
+		_putchar('m');
+		_putchar('o');
+		_putchar('\n');
 		BUSY_WAIT_ms(100);
+	}
+}
+
+SUPPRESS_UNUSED
+static void test_trace(void)
+{
+	test_setup();
+	uart_init();
+	while(1)
+	{
+		printf("Sumo robot %d\n",2024);
 	}
 }
 


### PR DESCRIPTION
The standard library printf implemenattion is not appropriate for a
microcontroller. A microcontroller has no notion of stdout and
standard printf implenetation has a big memory footprint. To get
around this, use a more stripped down external implementation,
mpland/printf, and include it as git submodule(already included).
Use this to implement a trace function that can format strings.