### PR TITLE
feat(ir_remote): driver to decode IR signal

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -67,6 +67,7 @@ SOURCES_WITH_HEADERS = \
 					   src/drivers/io.c \
 					   src/drivers/mcu_init.c \
 					   src/drivers/uart.c \
+					   src/drivers/ir_remote.c \
 					   external/printf/printf.c \
 
 

--- a/src/common/defines.h
+++ b/src/common/defines.h
@@ -7,6 +7,8 @@
 
 #define INTERRUPT_FUNCTION(vector) void __attribute__((interrupt(vector)))
 
+#define IS_ODD(x) (x & 1)
+
 // Clock rate calculation when it is set to default 1MHZ
 #define CYCLES_1MHZ (1000000u)
 #define CYCLES_16MHZ (16u * CYCLES_1MHZ)

--- a/src/common/ring_buffer.c
+++ b/src/common/ring_buffer.c
@@ -11,6 +11,11 @@ void ring_buffer_put(struct ring_buffer *rb, uint8_t data) {
   if (rb->head == rb->size) {
     rb->head = 0;
   }
+
+  // If ring_buffer is full, remove the oldest element
+  if (rb->head == rb->tail) {
+    rb->tail++;
+  }
 }
 
 // Retrive an element from the ring buffer

--- a/src/drivers/io.c
+++ b/src/drivers/io.c
@@ -100,13 +100,17 @@ static const struct io_config
         [IO_UART_TXD] = {IO_SELECT_ALT1, IO_PUPD_DISABLED, IO_DIR_OUTPUT,
                          IO_OUT_LOW},
 
+        /* Input (no resitor required according to data sheet of IR receiver)
+         */
+        [IO_IR_REMOTE] = {IO_SELECT_GPIO, IO_PUPD_DISABLED, IO_DIR_INPUT,
+                          IO_OUT_LOW},
+
 #if defined(LAUNCHPAD)
         // Unused pins
         [IO_UNUSED_1] = UNUSED_CONFIG,
         [IO_UNUSED_2] = UNUSED_CONFIG,
         [IO_UNUSED_3] = UNUSED_CONFIG,
         [IO_UNUSED_4] = UNUSED_CONFIG,
-        [IO_UNUSED_5] = UNUSED_CONFIG,
         [IO_UNUSED_6] = UNUSED_CONFIG,
         [IO_UNUSED_7] = UNUSED_CONFIG,
         [IO_UNUSED_8] = UNUSED_CONFIG,

--- a/src/drivers/io.h
+++ b/src/drivers/io.h
@@ -53,7 +53,7 @@ typedef enum {
   IO_UNUSED_2 = IO_15,
   IO_UNUSED_3 = IO_16,
   IO_UNUSED_4 = IO_17,
-  IO_UNUSED_5 = IO_20,
+  IO_IR_REMOTE = IO_20,
   IO_UNUSED_6 = IO_21,
   IO_UNUSED_7 = IO_22,
   IO_UNUSED_8 = IO_23,

--- a/src/drivers/ir_remote.c
+++ b/src/drivers/ir_remote.c
@@ -1,0 +1,187 @@
+#include "drivers/ir_remote.h"
+#include "common/defines.h"
+#include "common/ring_buffer.h"
+#include "drivers/io.h"
+#include <assert.h>
+#include <msp430.h>
+#include <stdint.h>
+
+#define TIMER_DIVIDER_ID_3 (8u)
+#define TIMER_MC_MASK (0x0030)
+#define TICKS_PER_ms (CYCLES_16MHZ / TIMER_DIVIDER_ID_3 / 1000u)
+#define TIMER_INTERRUPT_ms (1u)
+#define TIMER_INTERRUPT_TICKS (TICKS_PER_ms * TIMER_INTERRUPT_ms)
+static_assert(TIMER_INTERRUPT_TICKS <= 0xFFFF, "Ticks too large");
+
+#define TIMER_TIMEOUT_ms                                                       \
+  (150u) // the max time between 2 pulse is 100us so 150 is for safety
+
+#define IR_CMD_BUFFER_ELEM_CNT (10u)
+static uint8_t buffer[IR_CMD_BUFFER_ELEM_CNT];
+static struct ring_buffer ir_cmd_buffer = {.buffer = buffer,
+                                           .size = IR_CMD_BUFFER_ELEM_CNT};
+
+static union {
+  struct {
+    uint8_t cmd_inverted;
+    uint8_t cmd;
+    uint8_t addr_inverted;
+    uint8_t addr;
+  } decoded;
+  uint32_t raw;
+} ir_message;
+
+static uint8_t timer_ms = 0;
+static uint16_t pulse_count = 0;
+
+static void timer_init(void) {
+  /* Configure timer to trigger interrupt after TIMER_INTERRUPT_TICKS
+   * TASSEL_2: SMCLK
+   * ID_3: Input divider 8
+   */
+  TA1CTL = TASSEL_2 + ID_3;
+  TA1CCR0 = TIMER_INTERRUPT_TICKS;
+  TA1CCTL0 = CCIE;
+}
+
+static void timer_start(void) {
+  // MC_1 : Count up to CCR0
+  TA1CTL = (TA1CTL & ~TIMER_MC_MASK) + MC_1 + TACLR;
+  timer_ms = 0;
+}
+
+static void timer_stop(void) {
+  // MC_0 : Stop the counter
+  TA1CTL = (TA1CTL & ~TIMER_MC_MASK) | MC_0;
+}
+
+static inline bool is_bit_pulse(uint16_t pulse) {
+  return 3 <= pulse && pulse <= 34;
+}
+
+static inline bool is_message_pulse(uint16_t pulse) {
+  return pulse == 34 || (pulse > 36 && IS_ODD(pulse));
+}
+
+static inline bool is_valid_pulse(uint16_t pulse, uint32_t ms) {
+  // Roughly sanity check if pulse arrived within expected time
+  if (pulse == 1) {
+    return ms == 0;
+  } else if (pulse == 2) {
+    return ms < 10;
+  } else if (3 <= pulse && pulse <= 34) {
+    return ms < 5;
+  } else if (pulse == 35) {
+    return ms < 50;
+  } else if (pulse == 36) {
+    return ms < 5;
+  } else if (pulse >= 37 && IS_ODD(pulse)) {
+    return ms < 110;
+  } else if (pulse >= 37) {
+    // even
+    return ms < 5;
+  } else {
+    return false;
+  }
+}
+
+static void isr_pulse(void) {
+  timer_stop();
+  pulse_count++;
+
+  if (!is_valid_pulse(pulse_count, timer_ms)) {
+    pulse_count = 1; // Assume start of new message
+    ir_message.raw = 0;
+  }
+
+  else if (is_bit_pulse(pulse_count)) {
+    ir_message.raw <<= 1;
+    ir_message.raw += (timer_ms >= 2) ? 1 : 0;
+  }
+  if (is_message_pulse(pulse_count)) {
+    ring_buffer_put(&ir_cmd_buffer, ir_message.decoded.cmd);
+  }
+  timer_start();
+}
+
+/*
+void __attribute__((interrupt(PORT2_VECTOR))) isr_port2(void)
+{
+    if(P2IFG & BIT0)
+    {
+        isr_pulse();
+        P2IFG &= ~BIT0;  //clear
+    }
+}
+
+*/
+
+INTERRUPT_FUNCTION(TIMER1_A0_VECTOR) isr_timer_a0(void) {
+  if (timer_ms < TIMER_TIMEOUT_ms) {
+    timer_ms++;
+  } else {
+    timer_stop();
+    pulse_count = 0;
+    ir_message.raw = 0;
+    timer_ms = 0;
+  }
+}
+
+ir_cmd_e ir_remote_get_cmd(void) {
+  io_disable_interrupt(IO_IR_REMOTE); // Disable interrupt
+  ir_cmd_e cmd = IR_CMD_NONE;
+  if (!ring_buffer_empty(&ir_cmd_buffer)) {
+    cmd = ring_buffer_get(&ir_cmd_buffer);
+  }
+  io_enable_interrupt(IO_IR_REMOTE); // Enable interrupt
+  return cmd;
+}
+
+void ir_remote_init(void) {
+  io_configure_interrupt(IO_IR_REMOTE, IO_TRIGGER_FALLING,
+                         isr_pulse); // trigger on falling edge
+  io_enable_interrupt(IO_IR_REMOTE); // Enable interrupt
+  timer_init();
+}
+
+const char *ir_remote_cmd_to_string(ir_cmd_e cmd) {
+  switch (cmd) {
+  case IR_CMD_0:
+    return "0";
+  case IR_CMD_1:
+    return "1";
+  case IR_CMD_2:
+    return "2";
+  case IR_CMD_3:
+    return "3";
+  case IR_CMD_4:
+    return "4";
+  case IR_CMD_5:
+    return "5";
+  case IR_CMD_6:
+    return "6";
+  case IR_CMD_7:
+    return "7";
+  case IR_CMD_8:
+    return "8";
+  case IR_CMD_9:
+    return "9";
+  case IR_CMD_STAR:
+    return "STAR";
+  case IR_CMD_HASH:
+    return "HASH";
+  case IR_CMD_UP:
+    return "UP";
+  case IR_CMD_DOWN:
+    return "DOWN";
+  case IR_CMD_LEFT:
+    return "LEFT";
+  case IR_CMD_RIGHT:
+    return "RIGHT";
+  case IR_CMD_OK:
+    return "OK";
+  case IR_CMD_NONE:
+    return "NONE";
+  }
+  return "UNKNOWN";
+}

--- a/src/drivers/ir_remote.h
+++ b/src/drivers/ir_remote.h
@@ -1,0 +1,40 @@
+/*
+ * ir_remote.h
+ *
+ *  Created on: 06-Sep-2024
+ *      Author: kj
+ */
+
+#ifndef IR_REMOTE_H_
+#define IR_REMOTE_H_
+
+// A driver that decodes the commands sent to the IR receiver (NEC protocol)
+
+typedef enum {
+  IR_CMD_0,
+  IR_CMD_1,
+  IR_CMD_2,
+  IR_CMD_3,
+  IR_CMD_4,
+  IR_CMD_5,
+  IR_CMD_6,
+  IR_CMD_7,
+  IR_CMD_8,
+  IR_CMD_9,
+  IR_CMD_STAR,
+  IR_CMD_HASH,
+  IR_CMD_UP,
+  IR_CMD_DOWN,
+  IR_CMD_LEFT,
+  IR_CMD_RIGHT,
+  IR_CMD_OK,
+  IR_CMD_NONE,
+
+} ir_cmd_e;
+
+void ir_remote_init(void);
+ir_cmd_e ir_remote_get_cmd(void);
+
+const char *ir_remote_cmd_to_string(ir_cmd_e cmd);
+
+#endif /* IR_REMOTE_H_ */

--- a/src/drivers/mcu_init.c
+++ b/src/drivers/mcu_init.c
@@ -1,66 +1,77 @@
 #include "drivers/mcu_init.h"
 #include "common/assert_handler.h"
+#include "common/defines.h"
 #include "drivers/io.h"
 #include <msp430.h>
 
-/* static void init_clocks() { */
-/*     /1* The MSP430F5529 uses the UCS (Unified Clock System), so */
-/*      * we'll configure the DCO to 16 MHz using UCS registers. */
-/*      * The DCO (Digitally Controlled Oscillator) is a crucial part */
-/*      * of the clock system that provides the main clock signal (MCLK) */
-/*      * for the CPU and peripheral subsystems (SMCLK). */
-/*      *1/ */
+void SetVcoreUp(unsigned int level);
 
-/*     // Set DCO FLL reference to REFO (32.768 kHz crystal) */
-/*     // SELREF_2 selects REFOCLK as the FLL reference clock source. */
-/*     UCSCTL3 = SELREF_2; */
+static void init_clocks() {
+  /* The MSP430F5529 uses the UCS (Unified Clock System), so
+   * we'll configure the DCO to 16 MHz using UCS registers.
+   * The DCO (Digitally Controlled Oscillator) is a crucial part
+   * of the clock system that provides the main clock signal (MCLK)
+   * for the CPU and peripheral subsystems (SMCLK).
+   */
 
-/*     // Set DCO to 16 MHz */
-/*     // DCORSEL_5 sets the DCO range for the desired frequency (16 MHz). */
-/*     UCSCTL1 = DCORSEL_5; */
+  // Increase Vcore setting to support fsystem=16MHz
+  SetVcoreUp(0x01);
+  SetVcoreUp(0x02);
+  SetVcoreUp(0x03);
 
-/*     // Set DCO Multiplier for 16MHz */
-/*     // FLLD_1 specifies the FLL loop divider, and 488 is the multiplier. */
-/*     // The formula used is: (N + 1) * FLLRef = Fdco */
-/*     // (488 + 1) * 32768 = 16MHz */
-/*     UCSCTL2 = FLLD_1 + 488; */
+  // Set DCO FLL reference to REFO (32.768 kHz crystal)
+  // SELREF_2 selects REFOCLK as the FLL reference clock source.
+  UCSCTL3 = SELREF_2;
+  UCSCTL4 |= SELA_2;
 
-/*     // Disable the FLL control loop before configuring the DCO */
-/*     // SCG0 is a status register bit that controls the FLL. */
-/*     // Disabling the FLL (by setting SCG0) prevents it from adjusting the DCO
- */
-/*     // frequency during configuration. */
-/*     __bis_SR_register(SCG0); */
+  // Disable the FLL control loop before configuring the DCO.
+  // SCG0 is a status register bit that controls the FLL.
+  // Disabling the FLL (by setting SCG0) prevents it from adjusting the DCO
 
-/*     // Enable the FLL control loop to lock the DCO frequency */
-/*     // After configuration, we clear SCG0 to re-enable the FLL. */
-/*     // The FLL will now lock the DCO at the desired frequency. */
-/*     __bic_SR_register(SCG0); */
+  // frequency during configuration.
+  __bis_SR_register(SCG0);
 
-/*     // Delay for DCO to settle */
-/*     // We delay for 782000 cycles to allow the DCO to stabilize at 16 MHz. */
-/*     // This delay is crucial to ensure the clock system is stable before use.
- */
-/*     __delay_cycles(782000); */
+  // Set the lowest possible DCOx, MODx
+  UCSCTL0 = 0x0000;
 
-/*     // Loop until XT1, XT2 & DCO fault flags are cleared */
-/*     // UCSCTL7 holds the fault flags for the clock sources. */
-/*     // XT2OFFG, XT1LFOFFG, and DCOFFG are flags indicating faults in XT2,
- * XT1, */
-/*     // and DCO, respectively. */
-/*     // SFRIFG1 holds the global oscillator fault flag (OFIFG). */
-/*     // We clear these flags in a loop until all faults are resolved. */
-/*     do { */
-/*         UCSCTL7 &= ~(XT2OFFG + XT1LFOFFG + DCOFFG); */
-/*         SFRIFG1 &= ~OFIFG;            // Clear fault flags */
-/*     } while (SFRIFG1 & OFIFG);        // Test oscillator fault flag */
+  // Set DCO to 16 MHz
+  // DCORSEL_5 sets the DCO range for the desired frequency (16 MHz).
+  UCSCTL1 = DCORSEL_4;
 
-/*     // Additional stabilization check to ensure DCO is running at 16 MHz */
-/*     // The ASSERT macro checks if the DCO settings are correct: */
-/*     // UCSCTL1 should equal DCORSEL_5, and UCSCTL2 should equal 488. */
-/*     // If either condition is false, the ASSERT will trigger an error. */
-/*     ASSERT((UCSCTL1 == DCORSEL_5) && ((UCSCTL2 & 0x03FF) == 488)); */
-/* } */
+  // Set DCO Multiplier for 16MHz
+  // FLLD_1 specifies the FLL loop divider, and 488 is the multiplier.
+  // The formula used is: (N + 1) * FLLRef = Fdco
+  // (488 + 1) * 32768 = 16MHz
+  UCSCTL2 = FLLD_0 + 488;
+
+  // Enable the FLL control loop to lock the DCO frequency
+  // After configuration, we clear SCG0 to re-enable the FLL.
+  // The FLL will now lock the DCO at the desired frequency.
+  __bic_SR_register(SCG0);
+
+  // Delay for DCO to settle
+  // We delay for 782000 cycles to allow the DCO to stabilize at 16 MHz.
+  // This delay is crucial to ensure the clock system is stable before use.
+
+  __delay_cycles(782000);
+
+  // Loop until XT1, XT2 & DCO fault flags are cleared
+  // UCSCTL7 holds the fault flags for the clock sources.
+  // XT2OFFG, XT1LFOFFG, and DCOFFG are flags indicating faults in XT2, XT1,
+  // and DCO, respectively.
+  // SFRIFG1 holds the global oscillator fault flag (OFIFG).
+  // We clear these flags in a loop until all faults are resolved.
+  do {
+    UCSCTL7 &= ~(XT2OFFG + XT1LFOFFG + DCOFFG);
+    SFRIFG1 &= ~OFIFG;       // Clear fault flags
+  } while (SFRIFG1 & OFIFG); // Test oscillator fault flag
+
+  // Additional stabilization check to ensure DCO is running at 16 MHz
+  // The ASSERT macro checks if the DCO settings are correct:
+  // UCSCTL1 should equal DCORSEL_5, and UCSCTL2 should equal 488.
+  // If either condition is false, the ASSERT will trigger an error.
+  ASSERT((UCSCTL1 == DCORSEL_4) && ((UCSCTL2 & 0x03FF) == 488));
+}
 
 /* Watchdog is enabled by default and will reset the microcontroller
  * repeatedly if not explicitly stopped. */
@@ -72,11 +83,35 @@ void mcu_init(void) {
   watchdog_stop();
 
   // Initializes clock of 16MHZ
-  // init_clocks();
+  init_clocks();
 
   // Initializes Input/Output
   io_init();
 
   // Enables the Interrupt globally
   _enable_interrupts();
+}
+
+void SetVcoreUp(unsigned int level) {
+  // Open PMM registers for write
+  PMMCTL0_H = PMMPW_H;
+  // Set SVS/SVM high side new level
+  SVSMHCTL = SVSHE + SVSHRVL0 * level + SVMHE + SVSMHRRL0 * level;
+  // Set SVM low side to new level
+  SVSMLCTL = SVSLE + SVMLE + SVSMLRRL0 * level;
+  // Wait till SVM is settled
+  while ((PMMIFG & SVSMLDLYIFG) == 0)
+    ;
+  // Clear already set flags
+  PMMIFG &= ~(SVMLVLRIFG + SVMLIFG);
+  // Set VCore to new level
+  PMMCTL0_L = PMMCOREV0 * level;
+  // Wait till new level reached
+  if ((PMMIFG & SVMLIFG))
+    while ((PMMIFG & SVMLVLRIFG) == 0)
+      ;
+  // Set SVS/SVM low side to new level
+  SVSMLCTL = SVSLE + SVSLRVL0 * level + SVMLE + SVSMLRRL0 * level;
+  // Lock PMM registers for write access
+  PMMCTL0_H = 0x00;
 }

--- a/src/drivers/uart.c
+++ b/src/drivers/uart.c
@@ -23,7 +23,7 @@ static struct ring_buffer tx_buffer = {.buffer = buffer,
  * msp430x5xx family user guide.
  */
 
-#define SMCLK (1000000u)
+#define SMCLK (16000000u)
 #define BRCLK (SMCLK)
 #define UART_BAUD_RATE (115200u)
 

--- a/src/test/test.c
+++ b/src/test/test.c
@@ -4,6 +4,7 @@
 #include "drivers/led.h"
 #include "drivers/mcu_init.h"
 #include "drivers/uart.h"
+#include "drivers/ir_remote.h"
 #include <msp430.h>
 //#include "external/printf/printf.h"
 #include "common/trace.h"
@@ -204,6 +205,20 @@ static void test_trace(void)
 		BUSY_WAIT_ms(100);
 	}
 }
+
+SUPPRESS_UNUSED
+static void test_ir_remote(void)
+{
+	test_setup();
+	trace_init();
+	ir_remote_init();
+	while(1)
+	{
+		TRACE("Command %s", ir_remote_cmd_to_string(ir_remote_get_cmd()));
+		BUSY_WAIT_ms(250);
+	}
+}
+
 
 int main()
 {


### PR DESCRIPTION
The robot must be able to decode a start signal sent at each match start. This signal is sent from an IR transmitter and is picked up by the IR receiver on board. Implement a driver that decodes the signal by measuring the time between the pulses on the GPIO connected to the IR receiver. Besides the start signal, also use this functionality to control the robot with a remote control, which is useful during development.