### PR TITLE
fix(ir_remote): Issues related to decoding the IR signal

### DIFF
--- a/src/drivers/io.c
+++ b/src/drivers/io.c
@@ -245,11 +245,11 @@ static void io_set_interrupt_trigger(io_e io, io_trigger_e trigger) {
 
   switch (trigger) {
   case IO_TRIGGER_RISING:
-    *port_interrupt_edge_select_register[port] &= ~pin;
+    *port_interrupt_edge_select_register[port] |= pin;
     break;
 
   case IO_TRIGGER_FALLING:
-    *port_interrupt_edge_select_register[port] |= pin;
+    *port_interrupt_edge_select_register[port] &= ~pin;
     break;
   }
   /* Also clear the interrupt here, because even if interrupt

--- a/src/drivers/ir_remote.c
+++ b/src/drivers/ir_remote.c
@@ -14,8 +14,8 @@
 #define TIMER_INTERRUPT_TICKS (TICKS_PER_ms * TIMER_INTERRUPT_ms)
 static_assert(TIMER_INTERRUPT_TICKS <= 0xFFFF, "Ticks too large");
 
-#define TIMER_TIMEOUT_ms                                                       \
-  (150u) // the max time between 2 pulse is 100us so 150 is for safety
+// the max time between 2 pulse is 100us so 150 is for safety
+#define TIMER_TIMEOUT_ms (150u)
 
 #define IR_CMD_BUFFER_ELEM_CNT (10u)
 static uint8_t buffer[IR_CMD_BUFFER_ELEM_CNT];


### PR DESCRIPTION
The issue was the wrong configuration of RISING_TRIGGER and FALLING_TRIGGERin the io.c file. Made few changes in the file and the IR receiver is able to receive the signal from the remote.